### PR TITLE
Improve RequestPasswordResetHandler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ api.yaml
 *.tar.gz
 docker-compose.yml
 
+infomark-config.yml
+
 # static/
 # static
 

--- a/api/app/auth.go
+++ b/api/app/auth.go
@@ -278,6 +278,11 @@ func (rs *AuthResource) RequestPasswordResetHandler(w http.ResponseWriter, r *ht
 		return
 	}
 
+	if user.ConfirmEmailToken.Valid {
+		render.Render(w, r, ErrRender(errors.New("email not confirmed")))
+		return
+	}
+
 	user.ResetPasswordToken = null.StringFrom(auth.GenerateToken(32))
 	rs.Stores.User.Update(user)
 


### PR DESCRIPTION
Users should not be able to reset their password, while not activated. This leads to confusion otherwise.