### PR TITLE
Fix inconsistency in grade_responses.go

### DIFF
--- a/api/app/grade_responses.go
+++ b/api/app/grade_responses.go
@@ -66,7 +66,7 @@ func (body *GradeResponse) Render(w http.ResponseWriter, r *http.Request) error 
 func newGradeResponse(p *model.Grade, courseID int64) *GradeResponse {
 
 	fileURL := ""
-	if helper.NewSubmissionFileHandle(p.ID).Exists() {
+	if helper.NewSubmissionFileHandle(p.SubmissionID).Exists() {
 		fileURL = fmt.Sprintf("%s/api/v1/courses/%d/submissions/%d/file",
 			configuration.Configuration.Server.ExternalURL(),
 			courseID,


### PR DESCRIPTION
`newGradeResponse` incorrectly used the grade ID to determine the file name. The submission id must be used. Otherwise some requests break when the IDs of table `grades` and  table `submissions` diverge.