### PR TITLE
Add `Reply-To` field for emails from user

### DIFF
--- a/email/email.go
+++ b/email/email.go
@@ -32,6 +32,7 @@ import (
 // Email contains all information to use sendmail
 type Email struct {
 	From    string
+	ReplyTo string
 	To      string
 	Subject string
 	Body    string
@@ -55,6 +56,7 @@ func NewEmail(from string, toEmail string, subject string, body string) *Email {
 func NewEmailFromUser(from string, toEmail string, subject string, body string, user *model.User) *Email {
 	email := &Email{
 		From:    from,
+		ReplyTo: user.Email,
 		To:      toEmail,
 		Subject: subject,
 		Body:    fmt.Sprintf("%s\n\n----------\nSender is %s\nSent via InfoMark\n", body, user.FullName()),
@@ -136,6 +138,9 @@ func BackgroundSend(emails <-chan *Email) {
 func (sm *TerminalMailer) Send(e *Email) error {
 	fmt.Printf("From: %s\n", e.From)
 	fmt.Printf("To: %s\n", e.To)
+	if e.ReplyTo != "" {
+		fmt.Printf("Reply-To: %s\n", e.ReplyTo)
+	}
 	fmt.Printf("Subject: %s\n", e.Subject)
 	fmt.Printf("Content-Type: text/plain; charset=\"utf-8\"\n")
 	fmt.Printf("\n")
@@ -162,6 +167,9 @@ func (sm *SendMailer) Send(e *Email) error {
 
 	pw.Write([]byte(fmt.Sprintf("From: %s\n", e.From)))
 	pw.Write([]byte(fmt.Sprintf("To: %s\n", e.To)))
+	if e.ReplyTo != "" {
+		pw.Write([]byte(fmt.Sprintf("Reply-To: %s\n", e.ReplyTo)))
+	}
 	pw.Write([]byte(fmt.Sprintf("Subject: %s\n", e.Subject)))
 	pw.Write([]byte("Content-Type: text/plain; charset=\"utf-8\"\n"))
 	pw.Write([]byte("\n")) // blank line separating headers from body


### PR DESCRIPTION
**tl;dr** No way to respond to a users mail directly. `Reply-To` field does that

Long version:
Imagine a situation where a Tutor uses the *Send Mail to Group* Feature. Works perfectly but the recipient has no way to respond in his email client.
Fastest is to look up the address of the Tutor on the platform, hence opening a tab logging in, clicking 3-4 times, scrolling halve a page and so on.
It would be easier if senders address is included in email content or in the header.