### PR TITLE
Pr/patwie/updatepass

### DIFF
--- a/api/app/account_requests.go
+++ b/api/app/account_requests.go
@@ -155,6 +155,10 @@ func (body *AccountRequest) Bind(r *http.Request) error {
 
 	// encrypt new password, when given
 	if body.Account.PlainPassword != "" {
+		// check password length
+		if len(body.Account.PlainPassword) < configuration.Configuration.Server.Authentication.Password.MinLength {
+			return errors.New("password too short")
+		}
 		hash, err := auth.HashPassword(body.Account.PlainPassword)
 		body.Account.EncryptedPassword = hash
 		return err

--- a/api/app/account_test.go
+++ b/api/app/account_test.go
@@ -282,6 +282,25 @@ func TestAccount(t *testing.T) {
 			g.Assert(isPasswordValid).Equal(true)
 			g.Assert(userAfter.ConfirmEmailToken.Valid).Equal(false)
 		})
+		g.It("Should only change password when new password is long enough ", func() {
+
+			data := H{
+				"account": H{
+					"plain_password": "f",
+				},
+				"old_plain_password": "test",
+			}
+
+			w := tape.Patch("/api/v1/account", data, adminJWT)
+			g.Assert(w.Code).Equal(http.StatusBadRequest)
+
+			userAfter, err := stores.User.Get(1)
+			g.Assert(err).Equal(nil)
+			g.Assert(userAfter.Email).Equal("test@uni-tuebingen.de")
+
+			isPasswordValid := auth.CheckPasswordHash("test", userAfter.EncryptedPassword)
+			g.Assert(isPasswordValid).Equal(true)
+		})
 
 		g.It("should change avatar (jpg)", func() {
 			defer helper.NewAvatarFileHandle(1).Delete()


### PR DESCRIPTION
User can set too short password during update. We rely on the frontend for checking that. But we need to add a server-side check as well.